### PR TITLE
feat(issue-18): endpoint para subir PDF con archivo real

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,4 +1,4 @@
-from fastapi import FastAPI
+from fastapi import FastAPI, File, HTTPException, UploadFile
 
 from app.settings import get_settings
 
@@ -11,3 +11,20 @@ app = FastAPI(title=settings.app_name, version=settings.app_version)
 @app.get("/health")
 def health() -> dict[str, str]:
     return {"status": "ok"}
+
+
+@app.post("/documents/upload")
+async def upload_pdf(file: UploadFile = File(...)) -> dict[str, str | int]:
+    if file.content_type != "application/pdf":
+        raise HTTPException(status_code=400, detail="El archivo debe ser un PDF.")
+
+    file_bytes = await file.read()
+    if not file_bytes:
+        raise HTTPException(status_code=400, detail="El archivo esta vacio.")
+
+    return {
+        "filename": file.filename or "sin_nombre.pdf",
+        "content_type": file.content_type,
+        "size_bytes": len(file_bytes),
+        "status": "uploaded",
+    }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ dependencies = [
     "fastapi==0.115.0",
     "uvicorn[standard]==0.30.6",
     "httpx==0.27.2",
+    "python-multipart",
     "pypdf",
     "PyMuPDF",
 ]

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -1,0 +1,29 @@
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+
+client = TestClient(app)
+
+
+def test_upload_pdf_accepts_real_file() -> None:
+    files = {"file": ("documento.pdf", b"%PDF-1.4\ncontenido", "application/pdf")}
+
+    response = client.post("/documents/upload", files=files)
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "filename": "documento.pdf",
+        "content_type": "application/pdf",
+        "size_bytes": len(b"%PDF-1.4\ncontenido"),
+        "status": "uploaded",
+    }
+
+
+def test_upload_pdf_rejects_non_pdf_file() -> None:
+    files = {"file": ("texto.txt", b"hola", "text/plain")}
+
+    response = client.post("/documents/upload", files=files)
+
+    assert response.status_code == 400
+    assert response.json() == {"detail": "El archivo debe ser un PDF."}


### PR DESCRIPTION
Lo que agregue es ahora el cliente puede subir un pdf verifica que no este vacío y además lo comprobé con un test que agregue 