### PR TITLE
feat: CRUD

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,35 +1,54 @@
 # PDF Extract Text
 
+![Python](https://img.shields.io/badge/Python-3.10+-blue.svg?logo=python&logoColor=white)
+![FastAPI](https://img.shields.io/badge/FastAPI-005571?logo=fastapi)
+![MongoDB](https://img.shields.io/badge/MongoDB-%234ea94b.svg?logo=mongodb&logoColor=white)
+![Tkinter](https://img.shields.io/badge/UI-Tkinter-lightgrey)
+
+---
+
 ## Descripción
-Este proyecto fue desarrollado con el objetivo de extraer texto de archivos de una forma automática. 
+Este proyecto fue desarrollado con el objetivo de **extraer texto de archivos PDF** de una forma automática. 
 La idea surge para tener que evitarnos estar copiando contenido de una forma manual, facilitando así de una forma sencilla el procesamiento de documentos.
+
+---
 
 ## Objetivos
 Nuestro objetivo es desarrollar una herramienta simple y funcional que permita procesar archivos PDF y obtener su contenido de forma rápida y eficiente.
+
+---
 
 ## Funcionalidades
 - Permite extraer texto desde archivos PDF.
 - Facilita el manejo de información contenida en documentos.
 - Persistencia en base de datos para no reprocesar archivos idénticos (Deduplicación por Checksum).
-- Interfaz gráfica (GUI) para selección de archivos y descarga directa en formato `.txt`.
+- Interfaz gráfica (GUI) para selección de archivos, visualización del historial y descarga directa en formato `.txt`.
 - Procesamiento OCR para extraer texto de imágenes incrustadas.
+- Borrado lógico (Soft delete) y edición de estado de los documentos.
+
+---
 
 ## Arquitectura
 El proyecto funciona con una arquitectura cliente-servidor:
 
 - **Capa de presentación (Frontend):** Interfaz de escritorio desarrollada con Tkinter (`app/interface.py`).
 - **Capa de presentación (Backend):** Endpoints de FastAPI definidos en `app/main.py`.
+- **Capa de servicio:** Gestión estricta de estados y validación de reglas de negocio (`app/services/document_service.py`).
 - **Capa de lógica:** Procesamiento, cálculo de checksums y extracción de texto en `app/services/pdf_service.py`.
 - **Capa de datos:** Los documentos y sus textos extraídos se persisten en **MongoDB** para acceso rápido e histórico (`app/repositories/document_repository.py`).
+
+---
 
 ## Estructura
 - `app/interface.py`: Interfaz gráfica de usuario.
 - `app/main.py`: Aplicación FastAPI y endpoints.
-- `app/services/`: Lógica de extracción de texto, OCR y creación de documentos.
+- `app/services/`: Lógica de extracción de texto, OCR, gestión de estado y creación de documentos.
 - `app/repositories/`: Lógica de conexión a la base de datos MongoDB.
 - `app/settings.py`: Configuración de la aplicación.
 - `tests/`: Pruebas automatizadas.
 - `start.bat` / `start.sh`: Scripts para levantar el proyecto automáticamente.
+
+---
 
 ## Tecnologías usadas
 - Python 3.10+
@@ -42,6 +61,8 @@ El proyecto funciona con una arquitectura cliente-servidor:
 - Tkinter (Frontend)
 
 > Se planea resumen por IA
+
+---
 
 ## Requisitos Previos e Instalación
 Este proyecto utiliza **`uv`** para gestionar dependencias.
@@ -63,6 +84,7 @@ Este proyecto utiliza **`uv`** para gestionar dependencias.
     uv sync
     ```
 
+---
 
 ## Uso
 
@@ -82,6 +104,8 @@ start.bat
 ./start.sh
 ```
 
+---
+
 ## API
 
 Si deseas usar el backend de forma independiente sin la interfaz, estos son los endpoints disponibles:
@@ -100,6 +124,26 @@ Si deseas usar el backend de forma independiente sin la interfaz, estos son los 
 
   * Retorna: `filename`, `content_type`, `size_bytes`, `extracted_text`, `status`.
 
+* `GET /documents`
+
+  * Retorna la lista paginada del historial de documentos.
+
+  * Parámetros: `skip`, `limit`, `include_text`.
+
+* `GET /documents/{document_id}`
+
+  * Retorna un documento específico por su ID.
+
+  * Parámetros: `include_text`.
+
+* `PATCH /documents/{document_id}`
+
+  * Permite actualizar el nombre del archivo (`pdf_nombre`) o su `estado`.
+
+* `DELETE /documents/{document_id}`
+
+  * Realiza un borrado lógico del documento en la base de datos (queda oculto sin perderse).
+
 
 * `GET /documents/by-checksum/{checksum}`
   * Retorna un documento previamente procesado buscando por su hash SHA-256.
@@ -108,7 +152,7 @@ Si deseas usar el backend de forma independiente sin la interfaz, estos son los 
 * `GET /documents/{document_id}/download`
   * Descarga directamente el texto extraído de un documento como un archivo `.txt`.
 
-
+---
 
 ## Configuración
 
@@ -117,6 +161,8 @@ Las siguientes variables de entorno (o archivo `.env`) configuran el proyecto:
 * `APP_MAX_PDF_SIZE_BYTES`: límite máximo de tamaño de PDF en bytes. Por defecto es `5242880` (5 MB).
 * `MONGODB_URI`: URI de conexión a la base de datos (por defecto `mongodb://localhost:27017`).
 * `MONGODB_DB_NAME`: Nombre de la base de datos (por defecto `pdf-extractext`).
+
+---
 
 ## Pruebas
 

--- a/app/interface.py
+++ b/app/interface.py
@@ -1,5 +1,5 @@
 import tkinter as tk
-from tkinter import filedialog, messagebox
+from tkinter import filedialog, messagebox, ttk, simpledialog
 import requests
 from requests.exceptions import ConnectionError
 import logging
@@ -92,7 +92,6 @@ def extraer_texto():
 
 # Descargar TXT
 def descargar_txt():
-
     if not texto_extraido_global:
         logger.warning("TXT download attempted but no text is available in memory")
         messagebox.showwarning(
@@ -129,12 +128,154 @@ def descargar_txt():
         logger.debug("TXT save dialog cancelled by user")
 
 
+def abrir_historial():
+    logger.info("Opening document history window")
+    ventana_historial = tk.Toplevel(ventana)
+    ventana_historial.title("Historial de Documentos")
+    ventana_historial.geometry("850x400")
+    ventana_historial.config(bg="#1e1e1e")
+
+    # Tabla (Treeview)
+    columnas = ("ID", "Nombre", "Estado", "Fecha")
+    tree = ttk.Treeview(ventana_historial, columns=columnas, show="headings")
+    tree.heading("ID", text="ID MongoDB")
+    tree.heading("Nombre", text="Nombre del Archivo")
+    tree.heading("Estado", text="Estado")
+    tree.heading("Fecha", text="Fecha de Creación")
+    
+    tree.column("ID", width=200, anchor=tk.CENTER)
+    tree.column("Nombre", width=350, anchor=tk.W)
+    tree.column("Estado", width=100, anchor=tk.CENTER)
+    tree.column("Fecha", width=150, anchor=tk.CENTER)
+    
+    tree.pack(fill=tk.BOTH, expand=True, padx=20, pady=10)
+
+    # Funciones de la tabla
+    def cargar_lista():
+        logger.debug("Fetching document history from backend")
+        for row in tree.get_children():
+            tree.delete(row)
+        try:
+            response = requests.get("http://127.0.0.1:8000/documents?limit=50")
+            if response.status_code == 200:
+                docs = response.json().get("items", [])
+                logger.info("History loaded successfully: %d items retrieved", len(docs))
+                for d in docs:
+                    fecha = d.get("created_at", "")[:16].replace("T", " ")
+                    tree.insert("", tk.END, values=(d.get("_id"), d.get("pdf_nombre"), d.get("estado"), fecha))
+            else:
+                logger.error("Failed to load history: status_code=%d response=%s", response.status_code, response.text)
+                messagebox.showerror("Error", "No se pudo cargar el historial.")
+        except ConnectionError as e:
+            logger.error("Connection error while fetching history: %s", e)
+            messagebox.showerror("Error", "Servidor desconectado.")
+
+    def ver_texto():
+        global texto_extraido_global
+        seleccion = tree.selection()
+        if not seleccion:
+            logger.warning("Load text attempted but no document selected")
+            messagebox.showwarning("Advertencia", "Seleccioná un documento de la lista.")
+            return
+        
+        doc_id = tree.item(seleccion[0])['values'][0]
+        logger.info("Fetching text for document id: %s", doc_id)
+        
+        try:
+            resp = requests.get(f"http://127.0.0.1:8000/documents/{doc_id}?include_text=true")
+            if resp.status_code == 200:
+                data = resp.json().get("document", {})
+                texto = data.get("txt_contenido", "")
+                
+                texto_extraido_global = texto
+                texto_resultado.delete("1.0", tk.END)
+                texto_resultado.insert(tk.END, texto_extraido_global)
+                
+                logger.info("Text successfully loaded into main window for document id: %s", doc_id)
+                messagebox.showinfo("Éxito", "Texto cargado en la pantalla principal.")
+                ventana_historial.destroy()
+            else:
+                logger.error("Failed to load document text: status_code=%d response=%s", resp.status_code, resp.text)
+                messagebox.showerror("Error", "No se pudo cargar el documento.")
+        except ConnectionError as e:
+            logger.error("Connection error while fetching document text: %s", e)
+            messagebox.showerror("Error", "Servidor desconectado.")
+
+    def renombrar():
+        seleccion = tree.selection()
+        if not seleccion:
+            logger.warning("Rename attempted but no document selected")
+            messagebox.showwarning("Advertencia", "Seleccioná un documento de la lista.")
+            return
+        
+        doc_id = tree.item(seleccion[0])['values'][0]
+        nombre_actual = tree.item(seleccion[0])['values'][1]
+        
+        nuevo_nombre = simpledialog.askstring("Renombrar", "Nuevo nombre del PDF:", initialvalue=nombre_actual)
+        if nuevo_nombre and nuevo_nombre != nombre_actual:
+            logger.info("Attempting to rename document id: %s from '%s' to '%s'", doc_id, nombre_actual, nuevo_nombre)
+            try:
+                resp = requests.patch(f"http://127.0.0.1:8000/documents/{doc_id}", json={"pdf_nombre": nuevo_nombre})
+                if resp.status_code == 200:
+                    logger.info("Document successfully renamed")
+                    cargar_lista()
+                else:
+                    logger.error("Failed to rename document: status_code=%d response=%s", resp.status_code, resp.text)
+                    messagebox.showerror("Error", f"Fallo al renombrar: {resp.json().get('detail')}")
+            except ConnectionError as e:
+                logger.error("Connection error while renaming document: %s", e)
+                messagebox.showerror("Error", "Servidor desconectado.")
+        else:
+            logger.debug("Rename dialog cancelled by user or name unchanged")
+
+    def eliminar():
+        seleccion = tree.selection()
+        if not seleccion:
+            logger.warning("Delete attempted but no document selected")
+            messagebox.showwarning("Advertencia", "Seleccioná un documento de la lista.")
+            return
+        
+        doc_id = tree.item(seleccion[0])['values'][0]
+        if messagebox.askyesno("Confirmar", "¿Seguro que querés eliminar este documento de la base de datos?"):
+            logger.info("Attempting to delete document id: %s", doc_id)
+            try:
+                resp = requests.delete(f"http://127.0.0.1:8000/documents/{doc_id}")
+                if resp.status_code == 200:
+                    logger.info("Document successfully deleted")
+                    cargar_lista()
+                else:
+                    logger.error("Failed to delete document: status_code=%d response=%s", resp.status_code, resp.text)
+                    messagebox.showerror("Error", "No se pudo eliminar.")
+            except ConnectionError as e:
+                logger.error("Connection error while deleting document: %s", e)
+                messagebox.showerror("Error", "Servidor desconectado.")
+        else:
+            logger.debug("Delete confirmation cancelled by user")
+
+    # Botones del panel de historial
+    panel_botones = tk.Frame(ventana_historial, bg="#1e1e1e")
+    panel_botones.pack(pady=10)
+
+    btn_ver = tk.Button(panel_botones, text="Cargar Texto", command=ver_texto, bg="#2196F3", fg="black", font=("Arial", 10, "bold"))
+    btn_ver.pack(side=tk.LEFT, padx=5)
+
+    btn_renombrar = tk.Button(panel_botones, text="Renombrar", command=renombrar, bg="#FFEB3B", fg="black", font=("Arial", 10, "bold"))
+    btn_renombrar.pack(side=tk.LEFT, padx=5)
+
+    btn_eliminar = tk.Button(panel_botones, text="Eliminar", command=eliminar, bg="#F44336", fg="black", font=("Arial", 10, "bold"))
+    btn_eliminar.pack(side=tk.LEFT, padx=5)
+
+    btn_actualizar = tk.Button(panel_botones, text="Actualizar Lista", command=cargar_lista, bg="#4CAF50", fg="black", font=("Arial", 10, "bold"))
+    btn_actualizar.pack(side=tk.LEFT, padx=5)
+
+    cargar_lista()
+
 # Ventana principal
 logger.info("Initializing Extractor PDF Tkinter UI")
 ventana = tk.Tk()
 
 ventana.title("Extractor PDF")
-ventana.geometry("900x600")
+ventana.geometry("900x650")
 ventana.config(bg="#1e1e1e")
 
 # Título
@@ -200,6 +341,18 @@ boton_descargar = tk.Button(
 )
 
 boton_descargar.pack(pady=10)
+
+boton_historial = tk.Button(
+    ventana,
+    text="Ver Historial",
+    command=abrir_historial,
+    bg="#9C27B0",
+    fg="black",
+    font=("Arial", 12),
+    padx=10,
+    pady=5
+)
+boton_historial.pack(pady=5)
 
 # Área de texto
 texto_resultado = tk.Text(

--- a/app/interface.py
+++ b/app/interface.py
@@ -206,7 +206,7 @@ def renombrar_historial(tree):
         "Nuevo nombre del PDF:",
         initialvalue=nombre_actual
     )
-    
+
     if nuevo_nombre and nuevo_nombre != nombre_actual:
         logger.info(
             "Attempting to rename document id: %s from '%s' to '%s'",

--- a/app/interface.py
+++ b/app/interface.py
@@ -70,24 +70,23 @@ def extraer_texto():
             texto_resultado.insert(tk.END, texto_extraido_global)
 
         else:
-            logger.error("Backend request failed: status_code=%d response=%s", response.status_code, response.text)
-            messagebox.showerror(
-                "Error",
+            logger.error(
+                "Backend request failed: status_code=%d response=%s",
+                response.status_code,
                 response.text
             )
+            messagebox.showerror("Error", response.text)
 
     except ConnectionError:
         logger.error("Failed to connect to backend at http://127.0.0.1:8000")
         messagebox.showerror(
             "Error de Conexión",
-            "No se pudo conectar con el servidor backend.\n\nAsegurate de que Uvicorn esté corriendo en el puerto 8000."
+            "No se pudo conectar con el servidor backend.\n\n"
+            "Asegurate de que Uvicorn esté corriendo en el puerto 8000."
         )
     except Exception as e:
         logger.error("Exception occurred during text extraction: %s", e, exc_info=True)
-        messagebox.showerror(
-            "Error",
-            str(e)
-        )
+        messagebox.showerror("Error", str(e))
 
 
 # Descargar TXT
@@ -128,6 +127,146 @@ def descargar_txt():
         logger.debug("TXT save dialog cancelled by user")
 
 
+def cargar_lista_historial(tree):
+    logger.debug("Fetching document history from backend")
+    for row in tree.get_children():
+        tree.delete(row)
+    try:
+        response = requests.get("http://127.0.0.1:8000/documents?limit=50")
+        if response.status_code == 200:
+            docs = response.json().get("items", [])
+            logger.info("History loaded successfully: %d items retrieved", len(docs))
+            for d in docs:
+                fecha = d.get("created_at", "")[:16].replace("T", " ")
+                tree.insert(
+                    "",
+                    tk.END,
+                    values=(d.get("_id"), d.get("pdf_nombre"), d.get("estado"), fecha)
+                )
+        else:
+            logger.error(
+                "Failed to load history: status_code=%d response=%s",
+                response.status_code,
+                response.text
+            )
+            messagebox.showerror("Error", "No se pudo cargar el historial.")
+    except ConnectionError as e:
+        logger.error("Connection error while fetching history: %s", e)
+        messagebox.showerror("Error", "Servidor desconectado.")
+
+
+def ver_texto_historial(tree, ventana_historial):
+    global texto_extraido_global
+    seleccion = tree.selection()
+    if not seleccion:
+        logger.warning("Load text attempted but no document selected")
+        messagebox.showwarning("Advertencia", "Seleccioná un documento de la lista.")
+        return
+
+    doc_id = tree.item(seleccion[0])['values'][0]
+    logger.info("Fetching text for document id: %s", doc_id)
+
+    try:
+        resp = requests.get(f"http://127.0.0.1:8000/documents/{doc_id}?include_text=true")
+        if resp.status_code == 200:
+            data = resp.json().get("document", {})
+            texto = data.get("txt_contenido", "")
+
+            texto_extraido_global = texto
+            texto_resultado.delete("1.0", tk.END)
+            texto_resultado.insert(tk.END, texto_extraido_global)
+
+            logger.info("Text successfully loaded into main window for document id: %s", doc_id)
+            messagebox.showinfo("Éxito", "Texto cargado en la pantalla principal.")
+            ventana_historial.destroy()
+        else:
+            logger.error(
+                "Failed to load document text: status_code=%d response=%s",
+                resp.status_code,
+                resp.text
+            )
+            messagebox.showerror("Error", "No se pudo cargar el documento.")
+    except ConnectionError as e:
+        logger.error("Connection error while fetching document text: %s", e)
+        messagebox.showerror("Error", "Servidor desconectado.")
+
+
+def renombrar_historial(tree):
+    seleccion = tree.selection()
+    if not seleccion:
+        logger.warning("Rename attempted but no document selected")
+        messagebox.showwarning("Advertencia", "Seleccioná un documento de la lista.")
+        return
+
+    doc_id = tree.item(seleccion[0])['values'][0]
+    nombre_actual = tree.item(seleccion[0])['values'][1]
+
+    nuevo_nombre = simpledialog.askstring(
+        "Renombrar",
+        "Nuevo nombre del PDF:",
+        initialvalue=nombre_actual
+    )
+    
+    if nuevo_nombre and nuevo_nombre != nombre_actual:
+        logger.info(
+            "Attempting to rename document id: %s from '%s' to '%s'",
+            doc_id,
+            nombre_actual,
+            nuevo_nombre
+        )
+        try:
+            resp = requests.patch(
+                f"http://127.0.0.1:8000/documents/{doc_id}",
+                json={"pdf_nombre": nuevo_nombre}
+            )
+            if resp.status_code == 200:
+                logger.info("Document successfully renamed")
+                cargar_lista_historial(tree)
+            else:
+                logger.error(
+                    "Failed to rename document: status_code=%d response=%s",
+                    resp.status_code,
+                    resp.text
+                )
+                messagebox.showerror("Error", f"Fallo al renombrar: {resp.json().get('detail')}")
+        except ConnectionError as e:
+            logger.error("Connection error while renaming document: %s", e)
+            messagebox.showerror("Error", "Servidor desconectado.")
+    else:
+        logger.debug("Rename dialog cancelled by user or name unchanged")
+
+
+def eliminar_historial(tree):
+    seleccion = tree.selection()
+    if not seleccion:
+        logger.warning("Delete attempted but no document selected")
+        messagebox.showwarning("Advertencia", "Seleccioná un documento de la lista.")
+        return
+
+    doc_id = tree.item(seleccion[0])['values'][0]
+    msg = "¿Seguro que querés eliminar este documento de la base de datos?"
+    if messagebox.askyesno("Confirmar", msg):
+        logger.info("Attempting to delete document id: %s", doc_id)
+        try:
+            resp = requests.delete(f"http://127.0.0.1:8000/documents/{doc_id}")
+            if resp.status_code == 200:
+                logger.info("Document successfully deleted")
+                cargar_lista_historial(tree)
+            else:
+                logger.error(
+                    "Failed to delete document: status_code=%d response=%s",
+                    resp.status_code,
+                    resp.text
+                )
+                messagebox.showerror("Error", "No se pudo eliminar.")
+        except ConnectionError as e:
+            logger.error("Connection error while deleting document: %s", e)
+            messagebox.showerror("Error", "Servidor desconectado.")
+    else:
+        logger.debug("Delete confirmation cancelled by user")
+
+
+# Abrir Ventana de Historial
 def abrir_historial():
     logger.info("Opening document history window")
     ventana_historial = tk.Toplevel(ventana)
@@ -142,133 +281,59 @@ def abrir_historial():
     tree.heading("Nombre", text="Nombre del Archivo")
     tree.heading("Estado", text="Estado")
     tree.heading("Fecha", text="Fecha de Creación")
-    
+
     tree.column("ID", width=200, anchor=tk.CENTER)
     tree.column("Nombre", width=350, anchor=tk.W)
     tree.column("Estado", width=100, anchor=tk.CENTER)
     tree.column("Fecha", width=150, anchor=tk.CENTER)
-    
+
     tree.pack(fill=tk.BOTH, expand=True, padx=20, pady=10)
 
-    # Funciones de la tabla
-    def cargar_lista():
-        logger.debug("Fetching document history from backend")
-        for row in tree.get_children():
-            tree.delete(row)
-        try:
-            response = requests.get("http://127.0.0.1:8000/documents?limit=50")
-            if response.status_code == 200:
-                docs = response.json().get("items", [])
-                logger.info("History loaded successfully: %d items retrieved", len(docs))
-                for d in docs:
-                    fecha = d.get("created_at", "")[:16].replace("T", " ")
-                    tree.insert("", tk.END, values=(d.get("_id"), d.get("pdf_nombre"), d.get("estado"), fecha))
-            else:
-                logger.error("Failed to load history: status_code=%d response=%s", response.status_code, response.text)
-                messagebox.showerror("Error", "No se pudo cargar el historial.")
-        except ConnectionError as e:
-            logger.error("Connection error while fetching history: %s", e)
-            messagebox.showerror("Error", "Servidor desconectado.")
-
-    def ver_texto():
-        global texto_extraido_global
-        seleccion = tree.selection()
-        if not seleccion:
-            logger.warning("Load text attempted but no document selected")
-            messagebox.showwarning("Advertencia", "Seleccioná un documento de la lista.")
-            return
-        
-        doc_id = tree.item(seleccion[0])['values'][0]
-        logger.info("Fetching text for document id: %s", doc_id)
-        
-        try:
-            resp = requests.get(f"http://127.0.0.1:8000/documents/{doc_id}?include_text=true")
-            if resp.status_code == 200:
-                data = resp.json().get("document", {})
-                texto = data.get("txt_contenido", "")
-                
-                texto_extraido_global = texto
-                texto_resultado.delete("1.0", tk.END)
-                texto_resultado.insert(tk.END, texto_extraido_global)
-                
-                logger.info("Text successfully loaded into main window for document id: %s", doc_id)
-                messagebox.showinfo("Éxito", "Texto cargado en la pantalla principal.")
-                ventana_historial.destroy()
-            else:
-                logger.error("Failed to load document text: status_code=%d response=%s", resp.status_code, resp.text)
-                messagebox.showerror("Error", "No se pudo cargar el documento.")
-        except ConnectionError as e:
-            logger.error("Connection error while fetching document text: %s", e)
-            messagebox.showerror("Error", "Servidor desconectado.")
-
-    def renombrar():
-        seleccion = tree.selection()
-        if not seleccion:
-            logger.warning("Rename attempted but no document selected")
-            messagebox.showwarning("Advertencia", "Seleccioná un documento de la lista.")
-            return
-        
-        doc_id = tree.item(seleccion[0])['values'][0]
-        nombre_actual = tree.item(seleccion[0])['values'][1]
-        
-        nuevo_nombre = simpledialog.askstring("Renombrar", "Nuevo nombre del PDF:", initialvalue=nombre_actual)
-        if nuevo_nombre and nuevo_nombre != nombre_actual:
-            logger.info("Attempting to rename document id: %s from '%s' to '%s'", doc_id, nombre_actual, nuevo_nombre)
-            try:
-                resp = requests.patch(f"http://127.0.0.1:8000/documents/{doc_id}", json={"pdf_nombre": nuevo_nombre})
-                if resp.status_code == 200:
-                    logger.info("Document successfully renamed")
-                    cargar_lista()
-                else:
-                    logger.error("Failed to rename document: status_code=%d response=%s", resp.status_code, resp.text)
-                    messagebox.showerror("Error", f"Fallo al renombrar: {resp.json().get('detail')}")
-            except ConnectionError as e:
-                logger.error("Connection error while renaming document: %s", e)
-                messagebox.showerror("Error", "Servidor desconectado.")
-        else:
-            logger.debug("Rename dialog cancelled by user or name unchanged")
-
-    def eliminar():
-        seleccion = tree.selection()
-        if not seleccion:
-            logger.warning("Delete attempted but no document selected")
-            messagebox.showwarning("Advertencia", "Seleccioná un documento de la lista.")
-            return
-        
-        doc_id = tree.item(seleccion[0])['values'][0]
-        if messagebox.askyesno("Confirmar", "¿Seguro que querés eliminar este documento de la base de datos?"):
-            logger.info("Attempting to delete document id: %s", doc_id)
-            try:
-                resp = requests.delete(f"http://127.0.0.1:8000/documents/{doc_id}")
-                if resp.status_code == 200:
-                    logger.info("Document successfully deleted")
-                    cargar_lista()
-                else:
-                    logger.error("Failed to delete document: status_code=%d response=%s", resp.status_code, resp.text)
-                    messagebox.showerror("Error", "No se pudo eliminar.")
-            except ConnectionError as e:
-                logger.error("Connection error while deleting document: %s", e)
-                messagebox.showerror("Error", "Servidor desconectado.")
-        else:
-            logger.debug("Delete confirmation cancelled by user")
-
-    # Botones del panel de historial
     panel_botones = tk.Frame(ventana_historial, bg="#1e1e1e")
     panel_botones.pack(pady=10)
 
-    btn_ver = tk.Button(panel_botones, text="Cargar Texto", command=ver_texto, bg="#2196F3", fg="black", font=("Arial", 10, "bold"))
+    btn_ver = tk.Button(
+        panel_botones,
+        text="Cargar Texto",
+        command=lambda: ver_texto_historial(tree, ventana_historial),
+        bg="#2196F3",
+        fg="black",
+        font=("Arial", 10, "bold")
+    )
     btn_ver.pack(side=tk.LEFT, padx=5)
 
-    btn_renombrar = tk.Button(panel_botones, text="Renombrar", command=renombrar, bg="#FFEB3B", fg="black", font=("Arial", 10, "bold"))
+    btn_renombrar = tk.Button(
+        panel_botones,
+        text="Renombrar",
+        command=lambda: renombrar_historial(tree),
+        bg="#FFEB3B",
+        fg="black",
+        font=("Arial", 10, "bold")
+    )
     btn_renombrar.pack(side=tk.LEFT, padx=5)
 
-    btn_eliminar = tk.Button(panel_botones, text="Eliminar", command=eliminar, bg="#F44336", fg="black", font=("Arial", 10, "bold"))
+    btn_eliminar = tk.Button(
+        panel_botones,
+        text="Eliminar",
+        command=lambda: eliminar_historial(tree),
+        bg="#F44336",
+        fg="black",
+        font=("Arial", 10, "bold")
+    )
     btn_eliminar.pack(side=tk.LEFT, padx=5)
 
-    btn_actualizar = tk.Button(panel_botones, text="Actualizar Lista", command=cargar_lista, bg="#4CAF50", fg="black", font=("Arial", 10, "bold"))
+    btn_actualizar = tk.Button(
+        panel_botones,
+        text="Actualizar Lista",
+        command=lambda: cargar_lista_historial(tree),
+        bg="#4CAF50",
+        fg="black",
+        font=("Arial", 10, "bold")
+    )
     btn_actualizar.pack(side=tk.LEFT, padx=5)
 
-    cargar_lista()
+    cargar_lista_historial(tree)
+
 
 # Ventana principal
 logger.info("Initializing Extractor PDF Tkinter UI")

--- a/app/main.py
+++ b/app/main.py
@@ -1,14 +1,17 @@
 from __future__ import annotations
 
 import logging
+from datetime import datetime
+from typing import Literal
 
 from bson.objectid import ObjectId
-from fastapi import FastAPI, File, HTTPException, UploadFile
-from fastapi.responses import Response
 from dotenv import load_dotenv
+from fastapi import FastAPI, File, HTTPException, Query, UploadFile
+from fastapi.responses import Response
+from pydantic import BaseModel, Field
 
-from app.repositories.document_repository import DocumentRepository
 from app.settings import get_settings
+from app.services.document_service import DocumentService, InvalidStatusTransitionError
 from app.services.pdf_service import InvalidPDFError, process_pdf_upload
 
 load_dotenv()
@@ -23,12 +26,21 @@ logging.getLogger().setLevel(logging.INFO)
 EMPTY_FILE_ERROR_DETAIL = "El archivo está vacio."
 MAX_FILE_SIZE_ERROR_TEMPLATE = "El archivo supera el tamaño máximo permitido de {max_size} bytes."
 INVALID_CONTENT_TYPE_ERROR_DETAIL = "El archivo debe enviarse como application/pdf."
+INVALID_DOCUMENT_ID_ERROR_DETAIL = "ID de documento inválido."
+NO_UPDATE_FIELDS_ERROR_DETAIL = "No hay campos para actualizar."
+MAX_LIST_LIMIT = 100
 
 
 settings = get_settings()
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 app = FastAPI(title=settings.app_name, version=settings.app_version)
+
+
+class DocumentUpdate(BaseModel):
+    pdf_nombre: str | None = Field(default=None, min_length=1, max_length=200)
+    estado: Literal["pendiente", "ok", "error"] | None = None
+    error: str | None = Field(default=None, max_length=500)
 
 
 @app.get("/health")
@@ -38,18 +50,40 @@ def health() -> dict[str, str]:
 
 
 def _serialize_document(document: dict) -> dict:
-    document_copy = {
-        **document,
-        "_id": str(document.get("_id", "")),
-    }
+    document_copy = {**document}
+    document_id = document_copy.get("_id")
+    if document_id is not None:
+        document_copy["_id"] = str(document_id)
+
+    created_at = document_copy.get("created_at")
+    if isinstance(created_at, datetime):
+        document_copy["created_at"] = created_at.isoformat()
+
+    deleted_at = document_copy.get("deleted_at")
+    if isinstance(deleted_at, datetime):
+        document_copy["deleted_at"] = deleted_at.isoformat()
     return document_copy
+
+
+def _model_dump(model: BaseModel) -> dict:
+    if hasattr(model, "model_dump"):
+        return model.model_dump(exclude_unset=True)
+    return model.dict(exclude_unset=True)
+
+
+def _parse_document_id(document_id: str) -> ObjectId:
+    try:
+        return ObjectId(document_id)
+    except Exception as exc:
+        logger.warning("Invalid document ID format: %s. Error: %s", document_id, exc)
+        raise HTTPException(status_code=400, detail=INVALID_DOCUMENT_ID_ERROR_DETAIL) from exc
 
 
 @app.get("/documents/by-checksum/{checksum}")
 def get_document_by_checksum(checksum: str) -> dict[str, object]:
     logger.info("Requested document by checksum: %s", checksum)
-    repository = DocumentRepository()
-    document = repository.find_by_checksum(checksum)
+    service = DocumentService()
+    document = service.get_document_by_checksum(checksum)
 
     if document is None:
         logger.warning("Document not found for checksum: %s", checksum)
@@ -62,17 +96,96 @@ def get_document_by_checksum(checksum: str) -> dict[str, object]:
     }
 
 
+@app.get("/documents")
+def list_documents(
+    skip: int = Query(0, ge=0),
+    limit: int = Query(20, ge=1, le=MAX_LIST_LIMIT),
+    include_text: bool = False,
+) -> dict[str, object]:
+    logger.info("Listing documents: skip=%d limit=%d include_text=%s", skip, limit, include_text)
+    service = DocumentService()
+    documents = service.list_documents(skip=skip, limit=limit, include_text=include_text)
+
+    serialized_documents = [_serialize_document(document) for document in documents]
+    return {
+        "items": serialized_documents,
+        "count": len(serialized_documents),
+        "skip": skip,
+        "limit": limit,
+    }
+
+
+@app.get("/documents/{document_id}")
+def get_document_by_id(document_id: str, include_text: bool = True) -> dict[str, object]:
+    logger.info("Requested document by id: %s", document_id)
+    object_id = _parse_document_id(document_id)
+    service = DocumentService()
+    document = service.get_document_by_id(object_id, include_text=include_text)
+
+    if document is None:
+        logger.warning("Document not found for id: %s", document_id)
+        raise HTTPException(status_code=404, detail="Documento no encontrado.")
+
+    return {
+        "document_id": str(document.get("_id", "")),
+        "document": _serialize_document(document),
+    }
+
+
+@app.patch("/documents/{document_id}")
+def update_document(document_id: str, payload: DocumentUpdate) -> dict[str, object]:
+    logger.info("Updating document id: %s", document_id)
+    object_id = _parse_document_id(document_id)
+
+    updates = _model_dump(payload)
+    if updates.get("pdf_nombre") is None:
+        updates.pop("pdf_nombre", None)
+    if updates.get("estado") is None:
+        updates.pop("estado", None)
+
+    if not updates:
+        raise HTTPException(status_code=400, detail=NO_UPDATE_FIELDS_ERROR_DETAIL)
+
+    service = DocumentService()
+    try:
+        document = service.update_document(object_id, updates)
+    except InvalidStatusTransitionError as exc:
+        logger.warning("Invalid status transition for document_id=%s: %s", document_id, exc)
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    if document is None:
+        logger.warning("Update failed. Document not found for id: %s", document_id)
+        raise HTTPException(status_code=404, detail="Documento no encontrado.")
+
+    return {
+        "document_id": str(document.get("_id", "")),
+        "document": _serialize_document(document),
+    }
+
+
+@app.delete("/documents/{document_id}")
+def delete_document(document_id: str) -> dict[str, str]:
+    logger.info("Deleting document id: %s", document_id)
+    object_id = _parse_document_id(document_id)
+    service = DocumentService()
+    deleted = service.delete_document(object_id)
+
+    if not deleted:
+        logger.warning("Delete failed. Document not found for id: %s", document_id)
+        raise HTTPException(status_code=404, detail="Documento no encontrado.")
+
+    return {
+        "status": "deleted",
+    }
+
+
 @app.get("/documents/{document_id}/download")
 def download_document_text(document_id: str) -> Response:
     logger.info("Download requested for document_id: %s", document_id)
-    try:
-        object_id = ObjectId(document_id)
-    except Exception as exc:
-        logger.warning("Invalid document ID format: %s. Error: %s", document_id, exc)
-        raise HTTPException(status_code=400, detail="ID de documento inválido.")
+    object_id = _parse_document_id(document_id)
 
-    repository = DocumentRepository()
-    document = repository.find_by_id(object_id)
+    service = DocumentService()
+    document = service.get_document_by_id(object_id, include_text=True)
 
     if document is None:
         logger.warning("Download failed: Document not found for ID: %s", document_id)

--- a/app/repositories/document_repository.py
+++ b/app/repositories/document_repository.py
@@ -3,8 +3,9 @@ from __future__ import annotations
 
 import logging
 import os
+from datetime import datetime, timezone
 
-from pymongo import MongoClient
+from pymongo import MongoClient, ReturnDocument
 from bson.objectid import ObjectId
 
 logger = logging.getLogger(__name__)
@@ -41,10 +42,73 @@ class DocumentRepository:
         )
         return result.inserted_id
 
-    def find_by_id(self, document_id: ObjectId) -> dict | None:
-        logger.debug("Finding document by id=%s", document_id)
-        return self.collection.find_one({"_id": document_id})
+    def _not_deleted_filter(self) -> dict:
+        return {"$or": [{"deleted_at": None}, {"deleted_at": {"$exists": False}}]}
 
-    def find_by_checksum(self, checksum: str) -> dict | None:
+    def _apply_not_deleted_filter(self, base_query: dict, include_deleted: bool) -> dict:
+        if include_deleted:
+            return base_query
+
+        return {"$and": [base_query, self._not_deleted_filter()]}
+
+    def find_by_id(
+        self,
+        document_id: ObjectId,
+        include_text: bool = True,
+        include_deleted: bool = False,
+    ) -> dict | None:
+        logger.debug(
+            "Finding document by id=%s include_text=%s include_deleted=%s",
+            document_id,
+            include_text,
+            include_deleted,
+        )
+        query = self._apply_not_deleted_filter({"_id": document_id}, include_deleted)
+        projection = None if include_text else {"txt_contenido": 0}
+        return self.collection.find_one(query, projection)
+
+    def find_by_checksum(self, checksum: str, include_deleted: bool = False) -> dict | None:
         logger.debug("Finding document by checksum=%s", checksum)
-        return self.collection.find_one({"checksum_archivo": checksum})
+        query = self._apply_not_deleted_filter({"checksum_archivo": checksum}, include_deleted)
+        return self.collection.find_one(query)
+
+    def list_documents(
+        self,
+        *,
+        skip: int = 0,
+        limit: int = 20,
+        include_text: bool = False,
+        include_deleted: bool = False,
+    ) -> list[dict]:
+        logger.debug(
+            "Listing documents: skip=%d limit=%d include_text=%s",
+            skip,
+            limit,
+            include_text,
+        )
+        query = {} if include_deleted else self._not_deleted_filter()
+        projection = None if include_text else {"txt_contenido": 0}
+        cursor = self.collection.find(query, projection)
+
+        cursor = cursor.sort([("created_at", -1), ("_id", -1)]).skip(skip).limit(limit)
+        return list(cursor)
+
+    def update_document(self, document_id: ObjectId, updates: dict) -> dict | None:
+        logger.debug("Updating document id=%s fields=%s", document_id, list(updates.keys()))
+        query = self._apply_not_deleted_filter({"_id": document_id}, include_deleted=False)
+        return self.collection.find_one_and_update(
+            query,
+            {"$set": updates},
+            return_document=ReturnDocument.AFTER,
+        )
+
+    def delete_document(self, document_id: ObjectId) -> bool:
+        logger.debug("Soft deleting document id=%s", document_id)
+        query = self._apply_not_deleted_filter({"_id": document_id}, include_deleted=False)
+        deleted_at = datetime.now(timezone.utc)
+        result = self.collection.find_one_and_update(
+            query,
+            {"$set": {"deleted_at": deleted_at}},
+            return_document=ReturnDocument.AFTER,
+        )
+        return result is not None

--- a/app/services/document_builder.py
+++ b/app/services/document_builder.py
@@ -12,7 +12,7 @@ def construir_documento(
     texto_extraido: str,
     checksum_archivo: str,
     duracion_ms: int,
-    estado: str = "ok",
+    estado: str = "pendiente",
     error: str | None = None,
 ) -> dict:
 
@@ -33,5 +33,6 @@ def construir_documento(
         "estado": estado,
         "error": error,
         "created_at": datetime.now(timezone.utc),
+        "deleted_at": None,
         "duracion_ms": duracion_ms,
     }

--- a/app/services/document_service.py
+++ b/app/services/document_service.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import logging
+
+from bson.objectid import ObjectId
+
+from app.repositories.document_repository import DocumentRepository
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+
+ALLOWED_ESTADOS = {"pendiente", "ok", "error"}
+ALLOWED_ESTADO_TRANSITIONS = {
+    None: {"pendiente", "ok", "error"},
+    "pendiente": {"ok", "error"},
+    "error": {"pendiente"},
+    "ok": set(),
+}
+
+
+class InvalidStatusTransitionError(ValueError):
+    pass
+
+
+class DocumentService:
+    def __init__(self, repository: DocumentRepository | None = None) -> None:
+        self.repository = repository or DocumentRepository()
+
+    def list_documents(
+        self,
+        *,
+        skip: int = 0,
+        limit: int = 20,
+        include_text: bool = False,
+    ) -> list[dict]:
+        return self.repository.list_documents(skip=skip, limit=limit, include_text=include_text)
+
+    def get_document_by_id(self, document_id: ObjectId, include_text: bool = True) -> dict | None:
+        return self.repository.find_by_id(document_id, include_text=include_text)
+
+    def get_document_by_checksum(self, checksum: str) -> dict | None:
+        return self.repository.find_by_checksum(checksum)
+
+    def update_document(self, document_id: ObjectId, updates: dict) -> dict | None:
+        existing = self.repository.find_by_id(document_id, include_text=False)
+        if existing is None:
+            return None
+
+        if "estado" in updates:
+            self._validate_status_transition(existing.get("estado"), updates["estado"])
+
+        return self.repository.update_document(document_id, updates)
+
+    def delete_document(self, document_id: ObjectId) -> bool:
+        return self.repository.delete_document(document_id)
+
+    def _validate_status_transition(self, current_estado: str | None, new_estado: str) -> None:
+        if new_estado not in ALLOWED_ESTADOS:
+            raise InvalidStatusTransitionError(f"Estado invalido: {new_estado}")
+
+        if current_estado == new_estado:
+            return
+
+        allowed = ALLOWED_ESTADO_TRANSITIONS.get(current_estado, ALLOWED_ESTADOS)
+        if new_estado not in allowed:
+            raise InvalidStatusTransitionError(
+                f"Transicion de estado invalida: {current_estado} -> {new_estado}"
+            )

--- a/app/services/pdf_service.py
+++ b/app/services/pdf_service.py
@@ -182,6 +182,7 @@ def process_pdf_upload(
         texto_extraido=texto_extraido,
         checksum_archivo=checksum,
         duracion_ms=duration_ms,
+        estado="ok"
     )
 
     inserted_id = active_repository.save_document(document)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,3 +88,9 @@ exclude_lines = [
     "if __name__ == .__main__.:",
     "if TYPE_CHECKING:",
 ]
+
+[dependency-groups]
+dev = [
+    "pytest>=9.0.3",
+    "pytest-mock>=3.15.1",
+]

--- a/tests/test_document_builder.py
+++ b/tests/test_document_builder.py
@@ -34,6 +34,7 @@ class TestDocumentBuilder:
             "estado",
             "error",
             "created_at",
+            "deleted_at",
             "duracion_ms",
         }
 
@@ -80,10 +81,10 @@ class TestDocumentBuilder:
 
         assert result["checksum_algoritmo"] == "sha256"
 
-    def test_construir_documento_default_estado_is_ok(self) -> None:
+    def test_construir_documento_default_estado_is_pendiente(self) -> None:
         result = self._build_document()
 
-        assert result["estado"] == "ok"
+        assert result["estado"] == "pendiente"
 
     def test_construir_documento_custom_estado(self) -> None:
         result = self._build_document(estado="error")
@@ -110,6 +111,11 @@ class TestDocumentBuilder:
         result = self._build_document()
 
         assert isinstance(result["created_at"], datetime)
+
+    def test_construir_documento_deleted_at_is_none(self) -> None:
+        result = self._build_document()
+
+        assert result["deleted_at"] is None
 
     def test_construir_documento_preserves_duracion_ms(self) -> None:
         duracion_ms = 1500

--- a/tests/test_document_repository.py
+++ b/tests/test_document_repository.py
@@ -3,6 +3,7 @@ from unittest.mock import MagicMock
 
 import pytest
 from bson.objectid import ObjectId
+from pymongo import ReturnDocument
 
 from app.repositories.document_repository import DocumentRepository
 
@@ -35,6 +36,7 @@ class TestDocumentRepository:
             "estado": "ok",
             "error": None,
             "created_at": datetime.now(timezone.utc),
+            "deleted_at": None,
             "duracion_ms": 100,
         }
 
@@ -79,7 +81,15 @@ class TestDocumentRepository:
         result = repository.find_by_id(doc_id)
 
         assert result == expected_document
-        mock_collection.find_one.assert_called_once_with({"_id": doc_id})
+        mock_collection.find_one.assert_called_once_with(
+            {
+                "$and": [
+                    {"_id": doc_id},
+                    {"$or": [{"deleted_at": None}, {"deleted_at": {"$exists": False}}]},
+                ]
+            },
+            None,
+        )
 
     def test_find_document_by_id_returns_none_if_not_found(
         self,
@@ -91,6 +101,25 @@ class TestDocumentRepository:
         result = repository.find_by_id(ObjectId())
 
         assert result is None
+
+    def test_find_document_by_id_excludes_text_when_requested(
+        self,
+        repository: DocumentRepository,
+        mock_collection: MagicMock,
+    ) -> None:
+        doc_id = ObjectId()
+
+        repository.find_by_id(doc_id, include_text=False)
+
+        mock_collection.find_one.assert_called_once_with(
+            {
+                "$and": [
+                    {"_id": doc_id},
+                    {"$or": [{"deleted_at": None}, {"deleted_at": {"$exists": False}}]},
+                ]
+            },
+            {"txt_contenido": 0},
+        )
 
     def test_find_by_checksum_returns_document(
         self,
@@ -110,7 +139,12 @@ class TestDocumentRepository:
 
         assert result == expected_document
         mock_collection.find_one.assert_called_once_with(
-            {"checksum_archivo": checksum}
+            {
+                "$and": [
+                    {"checksum_archivo": checksum},
+                    {"$or": [{"deleted_at": None}, {"deleted_at": {"$exists": False}}]},
+                ]
+            }
         )
 
     def test_find_by_checksum_returns_none_if_not_found(
@@ -123,3 +157,92 @@ class TestDocumentRepository:
         result = repository.find_by_checksum("nonexistent_checksum")
 
         assert result is None
+
+    def test_list_documents_excludes_text_by_default(
+        self,
+        repository: DocumentRepository,
+        mock_collection: MagicMock,
+    ) -> None:
+        doc_id = ObjectId()
+        cursor = MagicMock()
+        cursor.sort.return_value = cursor
+        cursor.skip.return_value = cursor
+        cursor.limit.return_value = cursor
+        cursor.__iter__.return_value = iter([
+            {"_id": doc_id, "pdf_nombre": "test.pdf"}
+        ])
+        mock_collection.find.return_value = cursor
+
+        result = repository.list_documents()
+
+        mock_collection.find.assert_called_once_with(
+            {"$or": [{"deleted_at": None}, {"deleted_at": {"$exists": False}}]},
+            {"txt_contenido": 0},
+        )
+        assert result == [{"_id": doc_id, "pdf_nombre": "test.pdf"}]
+
+    def test_list_documents_includes_text_when_requested(
+        self,
+        repository: DocumentRepository,
+        mock_collection: MagicMock,
+    ) -> None:
+        cursor = MagicMock()
+        cursor.sort.return_value = cursor
+        cursor.skip.return_value = cursor
+        cursor.limit.return_value = cursor
+        cursor.__iter__.return_value = iter([
+            {"_id": ObjectId(), "pdf_nombre": "test.pdf", "txt_contenido": "text"}
+        ])
+        mock_collection.find.return_value = cursor
+
+        repository.list_documents(include_text=True)
+
+        mock_collection.find.assert_called_once_with(
+            {"$or": [{"deleted_at": None}, {"deleted_at": {"$exists": False}}]},
+            None,
+        )
+
+    def test_update_document_calls_find_one_and_update(
+        self,
+        repository: DocumentRepository,
+        mock_collection: MagicMock,
+    ) -> None:
+        doc_id = ObjectId()
+        updates = {"estado": "ok"}
+        updated_document = {"_id": doc_id, "estado": "ok"}
+        mock_collection.find_one_and_update.return_value = updated_document
+
+        result = repository.update_document(doc_id, updates)
+
+        mock_collection.find_one_and_update.assert_called_once_with(
+            {
+                "$and": [
+                    {"_id": doc_id},
+                    {"$or": [{"deleted_at": None}, {"deleted_at": {"$exists": False}}]},
+                ]
+            },
+            {"$set": updates},
+            return_document=ReturnDocument.AFTER,
+        )
+        assert result == updated_document
+
+    def test_delete_document_returns_true_on_success(
+        self,
+        repository: DocumentRepository,
+        mock_collection: MagicMock,
+    ) -> None:
+        doc_id = ObjectId()
+        mock_collection.find_one_and_update.return_value = {"_id": doc_id}
+
+        result = repository.delete_document(doc_id)
+
+        args, kwargs = mock_collection.find_one_and_update.call_args
+        assert args[0] == {
+            "$and": [
+                {"_id": doc_id},
+                {"$or": [{"deleted_at": None}, {"deleted_at": {"$exists": False}}]},
+            ]
+        }
+        assert "deleted_at" in args[1]["$set"]
+        assert kwargs["return_document"] == ReturnDocument.AFTER
+        assert result is True

--- a/tests/test_document_service.py
+++ b/tests/test_document_service.py
@@ -1,0 +1,82 @@
+from unittest.mock import MagicMock
+
+import pytest
+from bson.objectid import ObjectId
+
+from app.services.document_service import DocumentService, InvalidStatusTransitionError
+
+
+def test_update_document_returns_none_when_missing() -> None:
+    repository = MagicMock()
+    repository.find_by_id.return_value = None
+    service = DocumentService(repository=repository)
+
+    result = service.update_document(ObjectId(), {"estado": "pendiente"})
+
+    assert result is None
+
+
+def test_update_document_allows_pendiente_to_ok() -> None:
+    doc_id = ObjectId()
+    repository = MagicMock()
+    repository.find_by_id.return_value = {"_id": doc_id, "estado": "pendiente"}
+    repository.update_document.return_value = {"_id": doc_id, "estado": "ok"}
+    service = DocumentService(repository=repository)
+
+    result = service.update_document(doc_id, {"estado": "ok"})
+
+    assert result["estado"] == "ok"
+    repository.update_document.assert_called_once_with(doc_id, {"estado": "ok"})
+
+
+def test_update_document_allows_pendiente_to_error() -> None:
+    doc_id = ObjectId()
+    repository = MagicMock()
+    repository.find_by_id.return_value = {"_id": doc_id, "estado": "pendiente"}
+    repository.update_document.return_value = {"_id": doc_id, "estado": "error"}
+    service = DocumentService(repository=repository)
+
+    result = service.update_document(doc_id, {"estado": "error"})
+
+    assert result["estado"] == "error"
+    repository.update_document.assert_called_once_with(doc_id, {"estado": "error"})
+
+
+def test_update_document_allows_error_to_pendiente() -> None:
+    doc_id = ObjectId()
+    repository = MagicMock()
+    repository.find_by_id.return_value = {"_id": doc_id, "estado": "error"}
+    repository.update_document.return_value = {"_id": doc_id, "estado": "pendiente"}
+    service = DocumentService(repository=repository)
+
+    result = service.update_document(doc_id, {"estado": "pendiente"})
+
+    assert result["estado"] == "pendiente"
+    repository.update_document.assert_called_once_with(doc_id, {"estado": "pendiente"})
+
+
+def test_update_document_rejects_error_to_ok() -> None:
+    repository = MagicMock()
+    repository.find_by_id.return_value = {"_id": ObjectId(), "estado": "error"}
+    service = DocumentService(repository=repository)
+
+    with pytest.raises(InvalidStatusTransitionError):
+        service.update_document(ObjectId(), {"estado": "ok"})
+
+
+def test_update_document_rejects_ok_to_error() -> None:
+    repository = MagicMock()
+    repository.find_by_id.return_value = {"_id": ObjectId(), "estado": "ok"}
+    service = DocumentService(repository=repository)
+
+    with pytest.raises(InvalidStatusTransitionError):
+        service.update_document(ObjectId(), {"estado": "error"})
+
+
+def test_update_document_rejects_invalid_estado() -> None:
+    repository = MagicMock()
+    repository.find_by_id.return_value = {"_id": ObjectId(), "estado": "pendiente"}
+    service = DocumentService(repository=repository)
+
+    with pytest.raises(InvalidStatusTransitionError):
+        service.update_document(ObjectId(), {"estado": "desconocido"})

--- a/tests/test_documents_crud.py
+++ b/tests/test_documents_crud.py
@@ -1,0 +1,219 @@
+from datetime import datetime, timezone
+from unittest.mock import MagicMock
+
+from bson.objectid import ObjectId
+from fastapi.testclient import TestClient
+
+from app import main as main_module
+from app.services.document_service import InvalidStatusTransitionError
+
+
+client = TestClient(main_module.app)
+
+
+def test_list_documents_returns_serialized_items(monkeypatch) -> None:
+    document_id = ObjectId("507f1f77bcf86cd799439011")
+    service = MagicMock()
+    service.list_documents.return_value = [
+        {
+            "_id": document_id,
+            "pdf_nombre": "doc.pdf",
+        }
+    ]
+    monkeypatch.setattr(main_module, "DocumentService", lambda: service)
+
+    response = client.get("/documents")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["count"] == 1
+    assert body["items"][0]["_id"] == "507f1f77bcf86cd799439011"
+    service.list_documents.assert_called_once_with(skip=0, limit=20, include_text=False)
+
+
+def test_list_documents_respects_query_params(monkeypatch) -> None:
+    service = MagicMock()
+    service.list_documents.return_value = []
+    monkeypatch.setattr(main_module, "DocumentService", lambda: service)
+
+    response = client.get("/documents?skip=5&limit=10&include_text=true")
+
+    assert response.status_code == 200
+    service.list_documents.assert_called_once_with(skip=5, limit=10, include_text=True)
+
+
+def test_list_documents_serializes_datetime(monkeypatch) -> None:
+    document_id = ObjectId("507f1f77bcf86cd799439011")
+    created_at = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    service = MagicMock()
+    service.list_documents.return_value = [
+        {
+            "_id": document_id,
+            "created_at": created_at,
+        }
+    ]
+    monkeypatch.setattr(main_module, "DocumentService", lambda: service)
+
+    response = client.get("/documents")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["items"][0]["created_at"].startswith("2024-01-01T00:00:00")
+
+
+def test_get_document_by_id_returns_document(monkeypatch) -> None:
+    document_id = ObjectId("507f1f77bcf86cd799439011")
+    service = MagicMock()
+    service.get_document_by_id.return_value = {
+        "_id": document_id,
+        "pdf_nombre": "doc.pdf",
+    }
+    monkeypatch.setattr(main_module, "DocumentService", lambda: service)
+
+    response = client.get(f"/documents/{document_id}")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["document"]["_id"] == "507f1f77bcf86cd799439011"
+    service.get_document_by_id.assert_called_once_with(document_id, include_text=True)
+
+
+def test_get_document_by_id_excludes_text_when_requested(monkeypatch) -> None:
+    document_id = ObjectId("507f1f77bcf86cd799439011")
+    service = MagicMock()
+    service.get_document_by_id.return_value = {
+        "_id": document_id,
+        "pdf_nombre": "doc.pdf",
+    }
+    monkeypatch.setattr(main_module, "DocumentService", lambda: service)
+
+    response = client.get(f"/documents/{document_id}?include_text=false")
+
+    assert response.status_code == 200
+    service.get_document_by_id.assert_called_once_with(document_id, include_text=False)
+
+
+def test_get_document_by_id_returns_404_when_missing(monkeypatch) -> None:
+    service = MagicMock()
+    service.get_document_by_id.return_value = None
+    monkeypatch.setattr(main_module, "DocumentService", lambda: service)
+
+    response = client.get("/documents/507f1f77bcf86cd799439011")
+
+    assert response.status_code == 404
+    assert response.json() == {"detail": "Documento no encontrado."}
+
+
+def test_get_document_by_id_rejects_invalid_id() -> None:
+    response = client.get("/documents/id-invalido")
+
+    assert response.status_code == 400
+    assert response.json() == {"detail": main_module.INVALID_DOCUMENT_ID_ERROR_DETAIL}
+
+
+def test_update_document_updates_fields(monkeypatch) -> None:
+    document_id = ObjectId("507f1f77bcf86cd799439011")
+    service = MagicMock()
+    service.update_document.return_value = {
+        "_id": document_id,
+        "pdf_nombre": "nuevo.pdf",
+        "estado": "ok",
+    }
+    monkeypatch.setattr(main_module, "DocumentService", lambda: service)
+
+    response = client.patch(
+        f"/documents/{document_id}",
+        json={"pdf_nombre": "nuevo.pdf", "estado": "ok"},
+    )
+
+    assert response.status_code == 200
+    service.update_document.assert_called_once_with(
+        document_id,
+        {"pdf_nombre": "nuevo.pdf", "estado": "ok"},
+    )
+
+
+def test_update_document_rejects_empty_payload(monkeypatch) -> None:
+    service = MagicMock()
+    service.update_document.return_value = None
+    monkeypatch.setattr(main_module, "DocumentService", lambda: service)
+
+    response = client.patch("/documents/507f1f77bcf86cd799439011", json={})
+
+    assert response.status_code == 400
+    assert response.json() == {"detail": main_module.NO_UPDATE_FIELDS_ERROR_DETAIL}
+
+
+def test_update_document_returns_404_when_missing(monkeypatch) -> None:
+    service = MagicMock()
+    service.update_document.return_value = None
+    monkeypatch.setattr(main_module, "DocumentService", lambda: service)
+
+    response = client.patch(
+        "/documents/507f1f77bcf86cd799439011",
+        json={"estado": "ok"},
+    )
+
+    assert response.status_code == 404
+    assert response.json() == {"detail": "Documento no encontrado."}
+
+
+def test_update_document_rejects_invalid_status_transition(monkeypatch) -> None:
+    service = MagicMock()
+    service.update_document.side_effect = InvalidStatusTransitionError(
+        "Transicion de estado invalida: error -> ok"
+    )
+    monkeypatch.setattr(main_module, "DocumentService", lambda: service)
+
+    response = client.patch(
+        "/documents/507f1f77bcf86cd799439011",
+        json={"estado": "ok"},
+    )
+
+    assert response.status_code == 400
+    assert response.json() == {"detail": "Transicion de estado invalida: error -> ok"}
+
+
+def test_update_document_rejects_invalid_id() -> None:
+    response = client.patch("/documents/id-invalido", json={"estado": "ok"})
+
+    assert response.status_code == 400
+    assert response.json() == {"detail": main_module.INVALID_DOCUMENT_ID_ERROR_DETAIL}
+
+
+def test_update_document_rejects_invalid_estado_schema() -> None:
+    response = client.patch(
+        "/documents/507f1f77bcf86cd799439011",
+        json={"estado": "desconocido"},
+    )
+
+    assert response.status_code == 422
+
+
+def test_delete_document_returns_deleted_status(monkeypatch) -> None:
+    service = MagicMock()
+    service.delete_document.return_value = True
+    monkeypatch.setattr(main_module, "DocumentService", lambda: service)
+
+    response = client.delete("/documents/507f1f77bcf86cd799439011")
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "deleted"}
+
+
+def test_delete_document_returns_404_when_missing(monkeypatch) -> None:
+    service = MagicMock()
+    service.delete_document.return_value = False
+    monkeypatch.setattr(main_module, "DocumentService", lambda: service)
+
+    response = client.delete("/documents/507f1f77bcf86cd799439011")
+
+    assert response.status_code == 404
+    assert response.json() == {"detail": "Documento no encontrado."}
+
+
+def test_delete_document_rejects_invalid_id() -> None:
+    response = client.delete("/documents/id-invalido")
+
+    assert response.status_code == 400
+    assert response.json() == {"detail": main_module.INVALID_DOCUMENT_ID_ERROR_DETAIL}

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -109,6 +109,7 @@ def test_extraer_texto_falla_por_permisos_de_archivo(mocker):
     assert args[0] == "Error"
     assert "Permiso denegado" in args[1]
 
+
 def test_cargar_lista_historial_exito(mocker):
     mock_tree = MagicMock()
     mock_tree.get_children.return_value = ["row1"]
@@ -226,7 +227,7 @@ def test_abrir_historial_crea_ui(mocker):
     mocker.patch('app.interface.ttk.Treeview')
     mocker.patch('app.interface.tk.Frame')
     mocker.patch('app.interface.tk.Button')
-    
+
     mock_cargar = mocker.patch('app.interface.cargar_lista_historial')
 
     interface.abrir_historial()

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -108,3 +108,127 @@ def test_extraer_texto_falla_por_permisos_de_archivo(mocker):
     args, _ = mock_showerror.call_args
     assert args[0] == "Error"
     assert "Permiso denegado" in args[1]
+
+def test_cargar_lista_historial_exito(mocker):
+    mock_tree = MagicMock()
+    mock_tree.get_children.return_value = ["row1"]
+
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {
+        "items": [
+            {"_id": "111", "pdf_nombre": "test.pdf", "estado": "ok", "created_at": "2026-05-25T10:00:00"}
+        ]
+    }
+    mock_get = mocker.patch('app.interface.requests.get', return_value=mock_response)
+
+    interface.cargar_lista_historial(mock_tree)
+
+    mock_tree.delete.assert_called_once_with("row1")
+    mock_get.assert_called_once_with("http://127.0.0.1:8000/documents?limit=50")
+    mock_tree.insert.assert_called_with("", tk.END, values=("111", "test.pdf", "ok", "2026-05-25 10:00"))
+
+
+def test_ver_texto_historial_exito(mocker):
+    mock_tree = MagicMock()
+    mock_tree.selection.return_value = ["item1"]
+    mock_tree.item.return_value = {'values': ["doc_123", "viejo.pdf"]}
+    mock_ventana = MagicMock()
+
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {"document": {"txt_contenido": "texto recuperado"}}
+    mock_get = mocker.patch('app.interface.requests.get', return_value=mock_response)
+    mock_showinfo = mocker.patch('app.interface.messagebox.showinfo')
+
+    interface.texto_resultado.delete("1.0", tk.END)
+
+    interface.ver_texto_historial(mock_tree, mock_ventana)
+
+    mock_get.assert_called_with("http://127.0.0.1:8000/documents/doc_123?include_text=true")
+    assert interface.texto_extraido_global == "texto recuperado"
+    assert interface.texto_resultado.get("1.0", tk.END).strip() == "texto recuperado"
+    mock_showinfo.assert_called_once()
+    mock_ventana.destroy.assert_called_once()
+
+
+def test_renombrar_historial_exito(mocker):
+    mock_tree = MagicMock()
+    mock_tree.selection.return_value = ["item1"]
+    mock_tree.item.return_value = {'values': ["doc_123", "viejo.pdf"]}
+
+    mocker.patch('app.interface.simpledialog.askstring', return_value="nuevo_nombre.pdf")
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_patch = mocker.patch('app.interface.requests.patch', return_value=mock_response)
+    mock_cargar = mocker.patch('app.interface.cargar_lista_historial')
+
+    interface.renombrar_historial(mock_tree)
+
+    mock_patch.assert_called_with("http://127.0.0.1:8000/documents/doc_123", json={"pdf_nombre": "nuevo_nombre.pdf"})
+    mock_cargar.assert_called_once_with(mock_tree)
+
+
+def test_eliminar_historial_exito(mocker):
+    mock_tree = MagicMock()
+    mock_tree.selection.return_value = ["item1"]
+    mock_tree.item.return_value = {'values': ["doc_123", "viejo.pdf"]}
+
+    mocker.patch('app.interface.messagebox.askyesno', return_value=True)
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_delete = mocker.patch('app.interface.requests.delete', return_value=mock_response)
+    mock_cargar = mocker.patch('app.interface.cargar_lista_historial')
+
+    interface.eliminar_historial(mock_tree)
+
+    mock_delete.assert_called_with("http://127.0.0.1:8000/documents/doc_123")
+    mock_cargar.assert_called_once_with(mock_tree)
+
+
+def test_historial_acciones_sin_seleccion_muestra_advertencia(mocker):
+    mock_tree = MagicMock()
+    mock_tree.selection.return_value = []
+
+    mock_warning = mocker.patch('app.interface.messagebox.showwarning')
+
+    interface.ver_texto_historial(mock_tree, MagicMock())
+    interface.renombrar_historial(mock_tree)
+    interface.eliminar_historial(mock_tree)
+
+    assert mock_warning.call_count == 3
+
+
+def test_historial_acciones_error_de_conexion(mocker):
+    mock_tree = MagicMock()
+    mock_tree.selection.return_value = ["item1"]
+    mock_tree.item.return_value = {'values': ["doc_123", "viejo.pdf"]}
+
+    mocker.patch('app.interface.simpledialog.askstring', return_value="nuevo.pdf")
+    mocker.patch('app.interface.messagebox.askyesno', return_value=True)
+
+    mocker.patch('app.interface.requests.get', side_effect=requests.exceptions.ConnectionError("Failed"))
+    mocker.patch('app.interface.requests.patch', side_effect=requests.exceptions.ConnectionError("Failed"))
+    mocker.patch('app.interface.requests.delete', side_effect=requests.exceptions.ConnectionError("Failed"))
+
+    mock_showerror = mocker.patch('app.interface.messagebox.showerror')
+
+    interface.cargar_lista_historial(mock_tree)
+    interface.ver_texto_historial(mock_tree, MagicMock())
+    interface.renombrar_historial(mock_tree)
+    interface.eliminar_historial(mock_tree)
+
+    assert mock_showerror.call_count == 4
+
+
+def test_abrir_historial_crea_ui(mocker):
+    mocker.patch('app.interface.tk.Toplevel')
+    mocker.patch('app.interface.ttk.Treeview')
+    mocker.patch('app.interface.tk.Frame')
+    mocker.patch('app.interface.tk.Button')
+    
+    mock_cargar = mocker.patch('app.interface.cargar_lista_historial')
+
+    interface.abrir_historial()
+
+    mock_cargar.assert_called_once()

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -100,14 +100,14 @@ def test_upload_pdf_rejects_file_over_max_size(monkeypatch) -> None:
 
 def test_download_document_returns_txt_attachment(monkeypatch) -> None:
     document_id = ObjectId("507f1f77bcf86cd799439011")
-    repository = MagicMock()
-    repository.find_by_id.return_value = {
+    service = MagicMock()
+    service.get_document_by_id.return_value = {
         "_id": document_id,
         "pdf_nombre": "documento.pdf",
         "txt_contenido": "texto descargable",
     }
 
-    monkeypatch.setattr(main_module, "DocumentRepository", lambda: repository)
+    monkeypatch.setattr(main_module, "DocumentService", lambda: service)
 
     response = client.get(f"/documents/{document_id}/download")
 
@@ -118,9 +118,9 @@ def test_download_document_returns_txt_attachment(monkeypatch) -> None:
 
 
 def test_download_document_returns_404_for_missing_document(monkeypatch) -> None:
-    repository = MagicMock()
-    repository.find_by_id.return_value = None
-    monkeypatch.setattr(main_module, "DocumentRepository", lambda: repository)
+    service = MagicMock()
+    service.get_document_by_id.return_value = None
+    monkeypatch.setattr(main_module, "DocumentService", lambda: service)
 
     response = client.get("/documents/507f1f77bcf86cd799439011/download")
 
@@ -129,13 +129,13 @@ def test_download_document_returns_404_for_missing_document(monkeypatch) -> None
 
 
 def test_get_document_by_checksum_returns_document(monkeypatch) -> None:
-    repository = MagicMock()
-    repository.find_by_checksum.return_value = {
+    service = MagicMock()
+    service.get_document_by_checksum.return_value = {
         "_id": ObjectId("507f1f77bcf86cd799439011"),
         "pdf_nombre": "documento.pdf",
         "txt_contenido": "texto existente",
     }
-    monkeypatch.setattr(main_module, "DocumentRepository", lambda: repository)
+    monkeypatch.setattr(main_module, "DocumentService", lambda: service)
 
     response = client.get("/documents/by-checksum/checksum123")
 
@@ -147,9 +147,9 @@ def test_get_document_by_checksum_returns_document(monkeypatch) -> None:
 
 
 def test_get_document_by_checksum_returns_404_when_missing(monkeypatch) -> None:
-    repository = MagicMock()
-    repository.find_by_checksum.return_value = None
-    monkeypatch.setattr(main_module, "DocumentRepository", lambda: repository)
+    service = MagicMock()
+    service.get_document_by_checksum.return_value = None
+    monkeypatch.setattr(main_module, "DocumentService", lambda: service)
 
     response = client.get("/documents/by-checksum/checksum123")
 

--- a/uv.lock
+++ b/uv.lock
@@ -433,6 +433,12 @@ dev = [
     { name = "ruff" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+    { name = "pytest-mock" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "black", marker = "extra == 'dev'", specifier = "==26.3.1" },
@@ -452,6 +458,12 @@ requires-dist = [
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.32.0" },
 ]
 provides-extras = ["dev"]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "pytest", specifier = ">=9.0.3" },
+    { name = "pytest-mock", specifier = ">=3.15.1" },
+]
 
 [[package]]
 name = "pillow"
@@ -746,6 +758,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/7a/15/da3df99fd551507694a9b01f512a2f6cf1254f33601605843c3775f39460/pytest-cov-4.1.0.tar.gz", hash = "sha256:3904b13dfbfec47f003b8e77fd5b589cd11904a21ddf1ab38a64f204d6a10ef6", size = 63245, upload-time = "2023-05-24T18:44:56.845Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a7/4b/8b78d126e275efa2379b1c2e09dc52cf70df16fc3b90613ef82531499d73/pytest_cov-4.1.0-py3-none-any.whl", hash = "sha256:6ba70b9e97e69fcc3fb45bfeab2d0a138fb65c4d0d6a41ef33983ad114be8c3a", size = 21949, upload-time = "2023-05-24T18:44:54.079Z" },
+]
+
+[[package]]
+name = "pytest-mock"
+version = "3.15.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/68/14/eb014d26be205d38ad5ad20d9a80f7d201472e08167f0bb4361e251084a9/pytest_mock-3.15.1.tar.gz", hash = "sha256:1849a238f6f396da19762269de72cb1814ab44416fa73a8686deac10b0d87a0f", size = 34036, upload-time = "2025-09-16T16:37:27.081Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/cc/06253936f4a7fa2e0f48dfe6d851d9c56df896a9ab09ac019d70b760619c/pytest_mock-3.15.1-py3-none-any.whl", hash = "sha256:0a25e2eb88fe5168d535041d09a4529a188176ae608a6d249ee65abc0949630d", size = 10095, upload-time = "2025-09-16T16:37:25.734Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #48 

## Cambios principales
- Se agrego `DocumentService` para centralizar reglas de negocio (SRP).
- Maquina de estados estricta: `pendiente -> ok|error`, `error -> pendiente`, bloqueado `error -> ok`.
- Soft delete con `deleted_at` y filtros por defecto en repo.
- Validacion de esquema con `Literal` y tests nuevos/actualizados.

## Tests
- `uv run pytest`